### PR TITLE
Fix dependency version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["SwiftXLSX"]),
     ],
     dependencies: [
-        .package(name: "ZipArchive", url: "https://github.com/ZipArchive/ZipArchive.git", from: "2.3.0")
+        .package(url: "https://github.com/ZipArchive/ZipArchive.git", "2.3.0"..<"2.5.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
The latest version of ZipArchive updated the minimum supported OS versions, preventing us from using SwiftXLSX with less thant iOS 15